### PR TITLE
Switch to Slack's files_upload_v2 API and Patch scp Path

### DIFF
--- a/dsaT3/data_manager.py
+++ b/dsaT3/data_manager.py
@@ -176,7 +176,7 @@ class DataManager:
                         self.copy_file(sourcepath_scp, destpath, remote=True)
                     except subprocess.CalledProcessError as exc:
                         self.logger.error(
-                            f"scp returned non-zero error code copying {sourcepath_scp} to "
+                            f"/usr/bin/scp returned non-zero error code copying {sourcepath_scp} to "
                             f"{destpath} with output: {exc}")
                     else:
                         found[subband] = True
@@ -226,7 +226,7 @@ class DataManager:
                         self.copy_file(sourcepath_scp, destpath, remote=True)
                     except subprocess.CalledProcessError as exc:
                         self.logger.error(
-                            f"scp returned non-zero error code copying {sourcepath_scp} to "
+                            f"/usr/bin/scp returned non-zero error code copying {sourcepath_scp} to "
                             f"{destpath} with output: {exc}")
                     else:
                         found[subband] = True
@@ -481,14 +481,14 @@ class DataManager:
             return
 
         if remote:
-            print(f"Running scp {sourcepath} {destpath}")
-            self.logger.info(f"Running scp {sourcepath} {destpath}")
+            print(f"Running /usr/bin/scp {sourcepath} {destpath}")
+            self.logger.info(f"Running /usr/bin/scp {sourcepath} {destpath}")
             #subprocess.check_output(
-            #    f"scp {sourcepath} {destpath}", shell=True, stderr=subprocess.STDOUT)
-            os.system(f"scp {sourcepath} {destpath}")
+            #    f"/usr/bin/scp {sourcepath} {destpath}", shell=True, stderr=subprocess.STDOUT)
+            os.system(f"/usr/bin/scp {sourcepath} {destpath}")
         else:
             print("Running COPY {sourcepath} {destpath}")
-            self.logger.info("Running COPY {sourcepath} {destpath}")
+            self.logger.info(f"Running COPY {sourcepath} {destpath}")
             shutil.copy(str(sourcepath), str(destpath))
 
         self.logger.info(f"Copied {sourcepath} to {destpath}.")

--- a/dsaT3/filplot_funcs.py
+++ b/dsaT3/filplot_funcs.py
@@ -784,8 +784,6 @@ def filplot_entry(trigger_dict, toslack=True, classify=True,
                 #message = f"{os.path.basename(figname)} (VOEvent sent!)"
                 #else:
                 message = os.path.basename(figname)
-                #slack_client.files_upload(channels='candidates', file=figname, initial_comment=message)
-                #vishnu changes for the new upload api
                 slack_client.files_upload_v2(channel=candidate_slack_channel_id, initial_comment=message,file_uploads=[
                     {
                         "file": figname,

--- a/dsaT3/filplot_funcs.py
+++ b/dsaT3/filplot_funcs.py
@@ -47,7 +47,7 @@ with open(slack_file) as sf_handler:
     slack_token = sf_handler.read()
     slack_client = slack.WebClient(token=slack_token)
 
-
+candidate_slack_channel_id = "C01NUV2M0HM"
 plt.rcParams.update({
                     'font.size': 12,
                     'font.family': 'serif',
@@ -784,7 +784,14 @@ def filplot_entry(trigger_dict, toslack=True, classify=True,
                 #message = f"{os.path.basename(figname)} (VOEvent sent!)"
                 #else:
                 message = os.path.basename(figname)
-                slack_client.files_upload(channels='candidates', file=figname, initial_comment=message)
+                #slack_client.files_upload(channels='candidates', file=figname, initial_comment=message)
+                #vishnu changes for the new upload api
+                slack_client.files_upload_v2(channel=candidate_slack_channel_id, initial_comment=message,file_uploads=[
+                    {
+                        "file": figname,
+                        "filename": message,
+                    }
+                ])
             except slack.errors.SlackApiError as exc:
                 print(f'SlackApiError!: {str(exc)}')
         elif not real and not injected:

--- a/services/tasktrigger.py
+++ b/services/tasktrigger.py
@@ -54,8 +54,6 @@ if __name__ == "__main__":
                         tasks.remove(future)
                     else:
                         print(f'\tTask {future} failed with status {future.status}')
-                        #vishnu edits to debug failed with status error (21Nov25)
-                        #Task <Future: error, key: run_final-251120svtj> failed with status error
                         exc = future.exception()
                         print(f'\tException: {exc}')
                         tb = future.traceback()

--- a/services/tasktrigger.py
+++ b/services/tasktrigger.py
@@ -54,6 +54,12 @@ if __name__ == "__main__":
                         tasks.remove(future)
                     else:
                         print(f'\tTask {future} failed with status {future.status}')
+                        #vishnu edits to debug failed with status error (21Nov25)
+                        #Task <Future: error, key: run_final-251120svtj> failed with status error
+                        exc = future.exception()
+                        print(f'\tException: {exc}')
+                        tb = future.traceback()
+                        print("".join(tb.format()))
 
             de.put_dict('/mon/service/T3manager', {'cadence': 5, 'time': dsa_functions36.current_mjd()})
             sleep(5)


### PR DESCRIPTION
Slack's `files_upload()` API has been deprecated since Nov 12. More details about this is available here: https://docs.slack.dev/reference/methods/files.upload/


We’ve switched over to the supported `files_upload_v2` API. 

Also adds a temporary fix for the recent `scp command not found` issue by using the absolute path. A proper investigation is still needed for the root cause of this.